### PR TITLE
replace sb-vm::make-ea with sb-vm::ea

### DIFF
--- a/ports/sbcl.lisp
+++ b/ports/sbcl.lisp
@@ -90,17 +90,17 @@
 #+sb-cga-sse2
 (progn
   (defmacro ea-for-data (vector index)
-    `(sb-vm::make-ea :dword :base ,vector
-                     :disp (- (+ (* sb-vm:vector-data-offset sb-vm:n-word-bytes)
-                                 ;; 4 bytes per single-float
-                                 (* ,index 4))
-                              sb-vm:other-pointer-lowtag)))
+    `(sb-vm::ea (- (+ (* sb-vm:vector-data-offset sb-vm:n-word-bytes)
+                      ;; 4 bytes per single-float
+                      (* ,index 4))
+                   sb-vm:other-pointer-lowtag)
+                ,vector))
   (defmacro ea-for-slice (vector &optional (index 0))
-    `(sb-vm::make-ea :dword :base ,vector
-                     :disp (- (+ (* sb-vm:vector-data-offset sb-vm:n-word-bytes)
-                                 ;; 4 bytes per single-float, 16 per slice.
-                                 (* ,index 16))
-                              sb-vm:other-pointer-lowtag)))
+    `(sb-vm::ea (- (+ (* sb-vm:vector-data-offset sb-vm:n-word-bytes)
+                      ;; 4 bytes per single-float, 16 per slice.
+                      (* ,index 16))
+                   sb-vm:other-pointer-lowtag)
+                ,vector))
   (defmacro load-slice (xmm vector &optional (index 0))
     `(inst movaps ,xmm (ea-for-slice ,vector ,index)))
   (defmacro store-slice (xmm vector &optional (index 0))


### PR DESCRIPTION
SBCL had sb-vm::make-ea removed in sbcl-2.0.11-13-g0a3aad22d
Solves issue #7 

Tested with SBCL 2.1.0  2.0.11  1.4.16
`SB-CGA-TEST::CUBIC-ROOTS-ABOVE.1` fails , but it also failed before this change.
