### PR TITLE
Fix for REORIENT with vectors pointing same direction.

### DIFF
--- a/matrix.lisp
+++ b/matrix.lisp
@@ -250,11 +250,18 @@ element of V is ignored."
 	(nv2 (normalize v2)))
     (if (vec~ nv1 nv2)
 	(identity-matrix)
-        (let ((cp (cross-product nv1 nv2)))
+        (let ((cp (cross-product nv1 nv2))
+              (dot (dot-product nv1 nv2)))
           (if (zerop (vec-length cp))
-              (scale* -1.0 -1.0 -1.0)
-	      (rotate-around (normalize cp)
-		             (acos (dot-product nv1 nv2))))))))
+              ;; This means vectors must be pointing the same direction, or
+              ;; opposite directions. The cross product can't be used as
+              ;; an axis of rotation, so if they're pointing the same direction,
+              ;; use the identity transformation. If opposite directions, then
+              ;; flip.
+              (if (> (dot-product nv1 nv2) 0)
+                  +identity-matrix+
+                  (scale* -1f0 -1f0 -1f0))
+	      (rotate-around (normalize cp) (acos dot)))))))
 
 (declaim (ftype (sfunction (matrix) matrix) transpose-matrix))
 (defun transpose-matrix (matrix)

--- a/tests.lisp
+++ b/tests.lisp
@@ -417,6 +417,15 @@
           0.001)
   t)
 
+;; Edge case: vectors pointing in same direction.
+(deftest reorient.3
+    (vec~ (normalize (vec 1.0 0.0 0.0))
+          (transform-point (vec 1.0 0.0 0.0)
+                           (reorient (vec 1.0 0.0 0.0)
+                                     (vec 1.0 0.0 0.0)))
+          0.001)
+  t)
+
 (deftest inverse-matrix.1
     (let* ((ma (random-affine-matrix 100.0))
            (ma2 (inverse-matrix ma))


### PR DESCRIPTION
It's me again! Last PR fixed REORIENT for vectors pointing opposite directions, I just realised my fix doesn't cover the case where they're pointing the same direction.

Testing:

```
(rtest:do-tests)
Doing 56 pending tests of 56 tests total.
 ALLOC-VEC.1 VEC=.1 VEC=.2 VEC~.1 VEC~.2 COPY-VEC.1 %COPY-VEC.1
 %COPY-VEC.2 VEC+.1 %VEC+.1 VEC-.1 %VEC-.1 VEC*.1 %VEC*.1 VEC/.1 %VEC/.1
 DOT-PRODUCT DOT-PRODUCT.2 DOT-PRODUCT.3 HADAMARD-PRODUCT.1
 %HADAMARD-PRODUCT.1 VEC-LENGTH.1 VEC-LENGTH.2 VEC-LENGTH.3 NORMALIZE.1
 NORMALIZE.2 %NORMALIZE.1 VEC-LERP.1 %VEC-LERP.1 VEC-MIN.1 VEC-MAX.1
 CROSS-PRODUCT.1 MREF.1 MATRIXP.1 MATRIX= TRANSLATE.1 TRANSLATE.2
 TRANSLATE.3 SCALE.1 SCALE.2 MATRIX*.1 MATRIX*.2 ROTATE.1 ROTATE.2
 ROTATE-AROUND.1 REORIENT.1 REORIENT.2 REORIENT.3 INVERSE-MATRIX.1
 OPTIMIZE-ALLOCTION CUBIC-ROOTS.1
Test CUBIC-ROOTS-ABOVE.1 failed
Form: (LET ((N 0))
        (MAP-COEFFICIENTS
         (LAMBDA (A B C D)
           (LET ((ROOTS (MULTIPLE-VALUE-LIST (CUBIC-ROOTS-ABOVE 0.0 A B C D))))
             (DOLIST (X ROOTS)
               (WHEN (> X 0.0)
                 (INCF N)
                 (LET ((RES (+ (* A (EXPT X 3)) (* B (EXPT X 2)) (* C X) D)))
                   (UNLESS (< -0.001 RES 0.001)
                     (ERROR "cubic/above ~S ~S ~S ~S) => ~S : ~S, ~S" A B C D
                            ROOTS X RES)))))))
         4 -10.0 10.0 1.0)
        N)
Expected value: 132492
Actual value: 132754.
 NAN.1 NAN.2 NAN.3 NAN.4
1 out of 56 total tests failed: CUBIC-ROOTS-ABOVE.1.
```